### PR TITLE
GroupScreen shows groups

### DIFF
--- a/src/screens/GroupsScreen.js
+++ b/src/screens/GroupsScreen.js
@@ -1,16 +1,82 @@
 import React, { useEffect, useState } from "react";
-import { View, Text } from "react-native";
+import { View, Text, ActivityIndicator, FlatList } from "react-native";
 import { useUser } from "../context/UserContext.js";
 import styles from "../styles/Home.js";
+import { firestore, collection, onSnapshot, getDocs } from "../firebase/config";
 
-export default function HomeScreen() {
-  const user = useUser();
+export default function GroupScreen() {
+  const user = useUser(); //Hakee kirjautuneen käyttäjän
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user?.uid) return;  // Jos käyttäjää ei ole (uid undefined), älä tee mitään
+
+    const groupsRef = collection(firestore, "groups"); //"groups"-kokoelma Firestoressa
+
+    const unsubscribe = onSnapshot(groupsRef, async (snapshot) => {
+      const allGroups = snapshot.docs;
+      const userGroups = []; // Lista käyttäjän ryhmistä
+
+
+      // Käydään jokainen ryhmä läpi
+      for (const groupDoc of allGroups) {
+        // Haetaan subcollection "members" kyseisestä ryhmästä
+        const membersRef = collection(firestore, "groups", groupDoc.id, "members");
+        const membersSnapshot = await getDocs(membersRef);
+
+        const isMember = membersSnapshot.docs.some(
+          memberDoc => memberDoc.id === user.uid
+        );
+
+
+
+        // Jos käyttäjä kuuluu ryhmään, lisätään se listalle
+        if (isMember) {
+          const data = groupDoc.data();
+          
+          userGroups.push({
+            id: groupDoc.id,
+            name: data.groupName || "Nimetön ryhmä",
+            description: data.desc || "",
+            createdAt: data.createdAt
+          });
+        }
+      }
+
+      console.log("User groups:", userGroups); //Tää heittää consolii ryhmän nimen, kuvauksen ja id, demo hommia nii jätin tän viel
+      setGroups(userGroups);
+      setLoading(false);
+    });
+
+    return unsubscribe;
+  }, [user]);
 
   return (
     <View style={styles.container}>
-
       <Text style={styles.title}>Ryhmäsivu</Text>
 
+      {loading ? (
+         // Tää on se latauspyörä efekti ku dataa haetaan
+        <ActivityIndicator size="large" />
+      ) : groups.length === 0 ? (
+        <Text>Et kuulu vielä ryhmiin</Text>     // Jos käyttäjä ei kuulu vielä mihinkää ryhmää nii lukee tää
+      ) : (
+        <FlatList
+          data={groups}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View style={{ paddingVertical: 10 }}>
+              <Text style={{ fontSize: 16, fontWeight: "bold" }}>
+                {item.name}
+              </Text>
+              {item.description ? (
+                <Text style={{ color: "#555" }}>{item.description}</Text>
+              ) : null}
+            </View>
+          )}
+        />
+      )}
     </View>
   );
 }


### PR DESCRIPTION
Sain GroupScreen näyttämään nyt ryhmät missä käyttäjä on.
Käytössä tekniikkana että allekkain tulee ne ryhmät kaikki nii React Nativen Flatlist.

Eka hakee sen kirjautuneen käyttäjän ja sitte Groups ja lataa ne reaaliajassa allekkain GroupScreeniin.
Lukee kans siinä sitte aina ryhmän nimi ja ryhmän kuvaus samalla.
-Jos käyttäjä ei kuulu mihinkään ryhmään nii sitte on teksti Et kuulu mihinkään ryhmään.
-Jos ryhmällä ei oo nimeä nii se näkyy silti ja nimenä nimetön ryhmä.
-Tähän laitoin nyt ton <ActivityIndicator size="large" /> se on se lataus spinneri ku hakee jotaki dataa, tästä en oo varma ollaanko muualla käytetty? ois varmaan ihan hyvä olla kaikissa missä haetaan tietokannasta jotain tietoa :D Se löytyy React Nativesta

Kokeillaampa näkyykö kuva tuotoksesta täällä :D 

![KamuFinder Group](https://github.com/user-attachments/assets/b4c7e395-f820-4def-a0c5-ee6cd6615586)


1 rivi tulee console logiin vielä tekstiä minkä jätin tähän versioon mistä näkee ainakin mitä dataa liikkuu.
Koodiin laitoin kommentteja nyt kans aika paljon nii ymmärtää tuosta helposti

Seuraavana meillä pitää luoda GroupScreenChats 👍 