### PR TITLE
Kaveripyyntö inffot ja hyväksyminen/hylkäys

### DIFF
--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -21,6 +21,7 @@ const FRIENDS = 'friends'
 const USERSPRIVATECHATS = 'usersPrivateChats'
 const PRIVATECHATS = 'privateChats'
 const MESSAGES = 'messages'
+const FRIENDREQUESTS = 'friendRequests'
 
 const auth = initializeAuth(app, {
     persistence: getReactNativePersistence(ReactNativeAsyncStorage)
@@ -49,4 +50,5 @@ export {
     USERSPRIVATECHATS,
     PRIVATECHATS,
     MESSAGES,
+    FRIENDREQUESTS,
 };

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,10 +2,9 @@ import React, { useEffect, useState } from "react";
 import { View, Text, TouchableOpacity,Image, TextInput, Alert } from "react-native";
 import { useUser } from "../context/UserContext.js";
 import { useNavigation } from "@react-navigation/native";
-import { firestore, USERS, doc, getDoc, collection, onSnapshot} from "../firebase/config";
+import { firestore, USERS, FRIENDREQUESTS, doc, getDoc, collection, onSnapshot, addDoc, serverTimestamp,} from "../firebase/config";
 import styles from "../styles/Home.js";
 import { Ionicons } from "@expo/vector-icons";
-import NavbarBottom from "../components/NavbarBottom";
 import Logo from "../../assets/Logo.png";
 
 export default function HomeScreen() {
@@ -16,6 +15,9 @@ export default function HomeScreen() {
   const [ searchQuery , setSearchQuery ] = useState('');
   const [listOfUsers, setUsersList] = useState([]);
   const [friendsList, setFriendsList] = useState([]);
+  const [sentFriendRequests, setSentFriendRequests] = useState([]);
+  const [receivedFriendRequests, setReceivedFriendRequests] = useState([]);
+  const [allFriendRequests, setAllFriendRequests] = useState([]);
 
 
   useEffect(() => {
@@ -59,6 +61,28 @@ export default function HomeScreen() {
 
   }, [user]);
 
+  // Checks pending friend requests (sent and received)
+  useEffect(() => {
+    if(!user) return;
+    
+    const friendRequestsRef = collection(firestore, USERS, user.uid, FRIENDREQUESTS);
+    const unsubscribe = onSnapshot(friendRequestsRef, (snapshot) => {
+      const requests = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+      
+      // Filtteröi vain pending pyynnöt
+      const sent = requests.filter(r => r.fromUserId === user.uid && r.status === "pending");
+      const received = requests.filter(r => r.toUserId === user.uid && r.status === "pending");
+      
+      setSentFriendRequests(sent);
+      setReceivedFriendRequests(received);
+      
+      // Kaikki pyynnöt (pending ja declined) - estää uudestaan lähettämisen
+      setAllFriendRequests(requests);
+    });
+    
+    return () => unsubscribe();
+  }, [user]);
+
 
   // Handles the search query input, filters the list of users, and updates the filtered results
   const handleSearch =  (query) => {
@@ -89,9 +113,28 @@ export default function HomeScreen() {
     setFilteredUsers(results)
   };
 
+  // fuction to handle friend requests 
+  const handleFriendRequest = async (u) => {
 
-  const handleFriendRequest = (u) => {
-    Alert.alert("Ystävä pyyntö", `Nappia painettu käyttäjälle ${u.firstName} ${u.lastName}`)
+    try {
+      const currentUserRequestsRef = collection(firestore, USERS, user.uid, FRIENDREQUESTS)
+      const targetUserRequestsRef = collection(firestore, USERS, u.id, FRIENDREQUESTS)
+      
+      const requestData = {
+        fromUserId: user.uid,
+        toUserId: u.id,
+        status: "pending",
+        timestamp: serverTimestamp(),
+      }
+      await addDoc(currentUserRequestsRef, requestData)
+      await addDoc(targetUserRequestsRef, requestData)
+
+      Alert.alert("Pyyntö lähetetty", `Kaveripyyntö lähetetty käyttäjälle ${u.firstName} ${u.lastName}`)
+    } catch (error) {
+      console.error("Error sending friend request:", error)
+      Alert.alert("Virhe", "Kaveripyynnön lähetys epäonnistui.")
+    }
+
   }
 
 
@@ -125,11 +168,19 @@ export default function HomeScreen() {
             
             {filteredUsers.length > 0 ? (
               filteredUsers.map((u) => {
-                const isFriend = friendsList.some(f => f.id === u.id)
+                const isFriend = friendsList.some(f => f.id === u.id);
+                const userRequest = allFriendRequests.find(r => 
+                  (r.fromUserId === user.uid && r.toUserId === u.id) || 
+                  (r.toUserId === user.uid && r.fromUserId === u.id)
+                );
+                const hasRequest = !!userRequest;
+                const isPending = userRequest?.status === "pending";
+                const isDeclined = userRequest?.status === "declined";
+                
                 return (
                   <View key= {u.id} style={styles.friendReguestbutton}>
                     <Text> {u.firstName} {u.lastName} </Text>
-                    {!isFriend && (
+                    {!isFriend && !hasRequest && (
                       <TouchableOpacity
                         onPress={() => handleFriendRequest(u)}
                         style={{
@@ -141,7 +192,13 @@ export default function HomeScreen() {
                       >
                         <Text style={{ color: "#fff", fontWeight: "bold" }}>+</Text>
                       </TouchableOpacity>
-                    )}                  
+                    )}
+                    {isPending && (
+                      <Text style={{ color: "#999", fontSize: 12 }}>Odottavissa</Text>
+                    )}
+                    {isDeclined && (
+                      <Text style={{ color: "#aaa", fontSize: 12 }}>Hylätty</Text>
+                    )}
                   </View>
                 )
               

--- a/src/screens/Notifications.js
+++ b/src/screens/Notifications.js
@@ -1,16 +1,338 @@
-import React, { useEffect, useState } from "react";
-import { View, Text } from "react-native";
+import React, { use, useEffect, useState, useRef } from "react";
+import { View, Text, TouchableOpacity, Alert,  } from "react-native";
 import { useUser } from "../context/UserContext.js";
+import { firestore, USERS, FRIENDREQUESTS, doc, getDoc, onSnapshot, setDoc} from "../firebase/config";
+import { collection, deleteDoc, serverTimestamp, writeBatch, updateDoc} from "firebase/firestore";
+import { useNavigation } from '@react-navigation/native';
 import styles from "../styles/Home.js";
 
-export default function HomeScreen() {
+export default function Notifications() {
   const user = useUser();
+  const [friendRequests, setFriendRequests] = useState([]);
+  const [ sentFriendRequests, setSentFriendRequests] = useState([]);
+  const [notifications, setNotifications] = useState([]);
+  const navigation = useNavigation();
+  
+  // Use refs to track latest state without changing listener
+  const friendRequestsRef = useRef([]);
+  const notificationsRef = useRef([]);
+  const listenerSetupRef = useRef(false);
+
+  const newFriendRequests = friendRequests.filter(r => !r.read && r.status !== "declined");
+  const readFriendRequests = friendRequests.filter((r) => r.read && r.status !== "declined");
+  const newNotifications = notifications.filter(n => !n.read);
+  const readNotifications = notifications.filter((n) => n.read);
+
+  // Update refs whenever state changes
+  friendRequestsRef.current = friendRequests;
+  notificationsRef.current = notifications;
+
+
+  useEffect(() => {
+    if (!user) return;
+
+    const friendRequestsRef = collection(firestore, USERS, user.uid, FRIENDREQUESTS)
+    const unsubscribe = onSnapshot(friendRequestsRef, async (querySnapshot) => {
+
+      const incomming = []
+      const outgoing = []
+
+      for ( const docSnap of querySnapshot.docs) {
+        const data = docSnap.data()
+        let name = "Poistettu käyttäjä";
+        let Date = data.timestamp?.toDate?.() || null;
+
+        if (data.toUserId === user.uid) {
+          const fromUserSnap = await getDoc(doc(firestore, USERS, data.fromUserId))
+          if (fromUserSnap.exists()) {
+            const fromData = fromUserSnap.data()
+            name = `${fromData.firstName} ${fromData.lastName}` || "Tuntematon"
+          }
+          incomming.push({ id: docSnap.id, name, Date, ...data })
+
+        } else if (data.fromUserId === user.uid) {
+          const toUserSnap = await getDoc(doc(firestore, USERS, data.toUserId))
+          if (toUserSnap.exists()) {
+            const toData = toUserSnap.data()
+            name = `${toData.firstName} ${toData.lastName}` || "Tuntematon"
+          }
+          outgoing.push({ id: docSnap.id, name, Date, ...data })
+        }
+      }
+      setFriendRequests(incomming)
+      setSentFriendRequests(outgoing)
+  })
+
+    return () => unsubscribe(); 
+  }, [user]);
+
+
+  useEffect(() => {
+    if (!user) return;
+
+    const notificationsRef = collection(firestore, USERS, user.uid, "notifications");
+    const unsubscribe = onSnapshot(notificationsRef, (querySnapshot) => {
+      const notifications = [];
+      querySnapshot.forEach((doc) => {
+        notifications.push({ id: doc.id, ...doc.data() });
+      });
+      setNotifications(notifications);
+    });
+
+    return () => unsubscribe();
+  }, [user]);
+
+
+  // Mark items as read when leaving the screen (blur event)
+  useEffect(() => {
+    if (listenerSetupRef.current) {
+      return;
+    }
+    
+    listenerSetupRef.current = true;
+
+    const unsubscribeBlur = navigation.addListener('blur', async () => {
+      try {
+        await markFriendRequestsReadData(friendRequestsRef.current);
+      } catch (error) {
+        console.error('Error marking friend requests as read:', error);
+      }
+      
+      try {
+        await markNotificationsReadData(notificationsRef.current);
+      } catch (error) {
+        console.error('Error marking notifications as read:', error);
+      }
+    });
+
+    const unsubscribeFocus = navigation.addListener('focus', () => {
+      // Screen is now focused
+    });
+
+    return () => {
+      // Keep listeners alive throughout the session
+    };
+  }, [navigation]); 
+
+
+  
+
+  const handleAccept = async (req) => {
+    try {
+      const currentUserRef = doc(firestore, USERS, user.uid)
+      const otherUserRef = doc(firestore, USERS, req.fromUserId)
+
+      const currentUserSnap = await getDoc(currentUserRef)
+      const otherUserSnap = await getDoc(otherUserRef)
+
+
+      if (!otherUserSnap.exists()) {
+        Alert.alert(
+          "Virhe",
+          "Käyttäjä on poistettu, et voi hyväksyä tätä kaveripyyntöä"
+        );
+
+        await deleteDoc(doc(firestore, USERS, user.uid, FRIENDREQUESTS, req.id))
+        return;
+      } 
+
+
+      const currentUserData = currentUserSnap.data()
+      const otherUserData = otherUserSnap.data()
+
+      await setDoc(doc(firestore, USERS, user.uid, "friends", req.fromUserId), {
+        firstName: otherUserData.firstName,
+        lastName: otherUserData.lastName,
+        timestamp: serverTimestamp()
+      })
+
+      await setDoc(doc(firestore, USERS, req.fromUserId, "friends", user.uid), {
+        firstName: currentUserData.firstName,
+        lastName: currentUserData.lastName,
+        timestamp: serverTimestamp()
+      })
+
+      await deleteRequests(req);
+
+      await setDoc(doc(firestore, USERS, req.fromUserId, "notifications", req.id), {
+        type: "friend_accept",
+        message: `${currentUserData.firstName} ${currentUserData.lastName} hyväksyi kaveripyynnön`,
+        timestamp: serverTimestamp(),
+        fromUserId: user.uid,
+      })
+
+    }catch (error) {
+      console.error("Error accepting friend request:", error)
+    } 
+
+  }
+
+  const deleteRequests = async (req) => {
+    try {
+    await deleteDoc(doc(firestore, USERS, user.uid, FRIENDREQUESTS, req.id));
+  } catch (e) {
+    console.log("Ei löytynyt omaa requestia");
+  }
+
+  try {
+    await deleteDoc(doc(firestore, USERS, req.fromUserId, FRIENDREQUESTS, req.id));
+  } catch (e) {
+    console.log("Ei löytynyt toisen requestia");
+  }
+  }
+
+  const handleDecline = async (req) => {
+    try {
+      const requestRef = doc(firestore, USERS, user.uid, FRIENDREQUESTS, req.id)
+      await updateDoc(requestRef, { status: "declined" })
+
+      const otherRequestRef = doc(firestore, USERS, req.fromUserId, FRIENDREQUESTS, req.id)
+      await updateDoc(otherRequestRef, { status: "declined" })
+    } catch (error) {
+      console.error("Error declining friend request:", error)
+    } 
+  }
+
+  const markNotificationsReadData = async (notificationsData) => {
+    const unread = notificationsData.filter(n => !n.read);
+    
+    if (!unread.length || !user) return;
+
+    try {
+      const batch = writeBatch(firestore);
+      unread.forEach(n => {
+        const notifRef = doc(firestore, USERS, user.uid, "notifications", n.id);
+        batch.update(notifRef, { read: true });
+      });
+      await batch.commit();
+    } catch (error) {
+      console.error('Error marking notifications as read:', error);
+    }
+  };
+
+  const markFriendRequestsReadData = async (friendRequestsData) => {
+    const unread = friendRequestsData.filter(r => !r.read);
+    
+    if (!unread.length || !user) return;
+
+    try {
+      const batch = writeBatch(firestore);
+      unread.forEach(r => {
+        const reqRef = doc(firestore, USERS, user.uid, FRIENDREQUESTS, r.id);
+        batch.update(reqRef, { read: true });
+      });
+      await batch.commit();
+    } catch (error) {
+      console.error('Error marking friend requests as read:', error);
+    }
+  };
 
   return (
     <View style={styles.container}>
-
       <Text style={styles.title}>Ilmoitukset</Text>
 
+      {/* Uudet saapuneet pyynnöt */}
+      {newFriendRequests.length > 0 && <Text style={{ fontWeight: "bold" }}>Uudet saapuneet pyynnöt:</Text>}
+      {newFriendRequests.map((req) => (
+        <View
+          key={req.id}
+          style={{
+            marginBottom: 10,
+            padding: 10,
+            borderRadius: 8,
+            backgroundColor: req.read ? "#f0f0f0" : "#d1e7dd",
+            borderWidth: 1,
+            borderColor: "#ccc",
+          }}
+        >
+          <Text style={{ fontWeight: "bold", color: req.status === "declined" ? "red" : "black" }}>
+            {req.name} - {req.Date ? req.Date.toLocaleDateString() : ""} 
+            {req.status === "declined" ? " (Hylätty)" : ""}
+          </Text>
+          <View style={{ flexDirection: "row", gap: 10, marginTop: 5 }}>
+            <TouchableOpacity onPress={() => handleAccept(req)}>
+              <Text style={{ color: "green" }}>Hyväksy</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => handleDecline(req)}>
+              <Text style={{ color: "red" }}>X</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ))}
+
+      {/* Luetut saapuneet pyynnöt */}
+      {readFriendRequests.length > 0 && <Text style={{ fontWeight: "bold" }}>Luetut saapuneet pyynnöt:</Text>}
+      {readFriendRequests.map((req) => (
+        <View
+          key={req.id}
+          style={{
+            marginBottom: 10,
+            padding: 10,
+            borderRadius: 8,
+            backgroundColor: "#f0f0f0",
+            borderWidth: 1,
+            borderColor: "#ccc",
+          }}
+        >
+          <Text style={{ fontWeight: "bold" }}>{req.name} - {req.Date ? req.Date.toLocaleDateString() : ""}</Text>
+          <View style={{ flexDirection: "row", gap: 10, marginTop: 5 }}>
+            <TouchableOpacity onPress={() => handleAccept(req)}>
+              <Text style={{ color: "green" }}>Hyväksy</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => handleDecline(req)}>
+              <Text style={{ color: "red" }}>X</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ))}
+
+      {/* Lähetetyt pyynnöt */}
+      {sentFriendRequests.filter(r => r.status !== "declined").length > 0 && <Text style={{ fontWeight: "bold" }}>Lähetetyt odottavat pyynnöt:</Text>}
+      {sentFriendRequests.filter(r => r.status !== "declined").map((req) => (
+        <Text key={req.id}>{req.name} - {req.Date ? req.Date.toLocaleDateString() : ""}</Text>
+      ))}
+
+      {/* Notifications */}
+      {newNotifications.length > 0 && <Text style={{ fontWeight: "bold" }}>Uudet ilmoitukset:</Text>}
+      {newNotifications.map((notif) => (
+        <View
+          key={notif.id}
+          style={{
+            padding: 10,
+            marginBottom: 5,
+            borderRadius: 8,
+            backgroundColor: notif.read ? "#f0f0f0" : "#ffeeba", 
+            borderWidth: 1,
+            borderColor: "#ccc",
+          }}
+        >
+          <Text style={{ fontWeight: "bold" }}>{notif.message}</Text>
+          <Text style={{ fontSize: 12, color: "#555" }}>
+            {notif.timestamp?.toDate ? notif.timestamp.toDate().toLocaleDateString() : ""}
+          </Text>
+        </View>
+      ))}
+
+      {readNotifications.length > 0 && <Text style={{ fontWeight: "bold" }}>Luetut ilmoitukset:</Text>}
+      {readNotifications.map((notif) => (
+        <View
+          key={notif.id}
+          style={{
+            padding: 10,
+            marginBottom: 5,
+            borderRadius: 8,
+            backgroundColor: "#f0f0f0",
+            borderWidth: 1,
+            borderColor: "#ccc",
+          }}
+        >
+          <Text>{notif.message}</Text>
+          <Text style={{ fontSize: 12, color: "#555" }}>
+            {notif.timestamp?.toDate ? notif.timestamp.toDate().toLocaleDateString() : ""}
+          </Text>
+        </View>
+      ))}
     </View>
   );
 }
+


### PR DESCRIPTION
Eli mitä tässä on tehty:
- käyttäjä voi hakea tyyppejä ja lähettää heille onnistuneesti kaveripyynnön. Sellaisille jotka on kerran hylännyt pyynnön tai on aktiivinen pyyntö käynnissä ei voi lähettää uutta.
- Ilmoitus sivulle tulee näkymään uudet kaveripyynnöt ja muut ilmoitukset ( muut ilmoitukset lisätty ilmoituksiin XD, tällä saadaan hyväksytyistä kaveripyynnöistä ja esim sinut lisättiin ryhmään ilmoitus)
- Ilmoitus sivulla olevat kaveripyynnöt ja muut ilmoitukset näkyy ekana kertana lukemattomissa ( värillinen) ja jos käyttäjä poistuu toiselle sivulle, ne muuttuu luetuiksi ja menee harmaaksi.
- Käyttäjän lähettämät pyynnöt näkyy täällä pending tilassa harmaana. Jos toinen decline niin ei ilmoo, poistuu vaan, jos acchept niin sitten ilmo että tää hyväksy ja lisätään käyttäjän kaveriksi.
- Jos käyttäjä hylkää kaveripyynnön jonka on saanut se laittaa tilaksi status=declined molemmille käyttäjille.
- Jos käyttäjä hyväksyy se lisää kaverit toistensa friendlistaan ja poistaa sen pyynnön. Tässä mulla ei aina poistanut toisen käyttäjän pyyntöä niin haluisin testaa porukalla että mitä käy, teoriassa pitäisi toimia :)

-Ainiin ja laitoin että jos olisi teoreettinen poistettu käyttäjä aka se pyynnön fromUserId ei vastaa minkään käyttäjän id se sanoo että tätä pyyntöä ei voi hyväksyä kun poistunut käyttäjä. Unohin tehä sen saman toiminnon sille hylkäykselle, joten antaa siittä erroria atm vaikka kyllä poistaa ne taulut. Korjaan tän seuraavaan pull req. 

Siinä tais olla kaikki. Kun tuota uita tuohon tekee niin read=false niin on väri, read= true harmaa. Ja ei kai muuta. Toi että sai noi luetuksi vasta kun käyttäjä poistuu sivulta oli ihan pain. Mut nyt pitäisi toimia.