### PR TITLE
Create public groups

### DIFF
--- a/src/screens/GroupsScreen.js
+++ b/src/screens/GroupsScreen.js
@@ -63,7 +63,7 @@ export default function GroupScreen() {
   const [groupName, setGroupName] = useState("");
   const [groupDescription, setGroupDescription] = useState("");
 
-  // ⭐ PUBLIC GROUP ADDITION
+ 
   const [isPublicGroup, setIsPublicGroup] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Nyt ryhmää luodessa voi klikata "Luo julkinen ryhmä".

Kun tekee julkisen ryhmän nii **kutsutut ystävät saavat samalla admin oikeudet sekä ryhmän luoja.**

Myöhemmin jotka liittyy niin saavat member oikeuden.

Tietokantaan laitoin nyt myös Groups/GroupID/isPublic = (true/false) se määrittää sitte onko julkinen vai ei.