### PR TITLE
Ilmot kotinäytölle ja kaverin poisto

### DIFF
--- a/src/components/DeleteFriend.js
+++ b/src/components/DeleteFriend.js
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { TouchableOpacity, Alert,} from "react-native";
+import {firestore,USERS,doc, FRIENDS, USERSPRIVATECHATS, PRIVATECHATS} from "../firebase/config.js";
+import { deleteDoc } from "firebase/firestore";
+import { useUser } from "../context/UserContext.js";
+import { Ionicons } from "@expo/vector-icons";
+
+
+export default function DeleteFriend({friendId, onRemoved}) {
+    const [isDeleting, setIsDeleting] = useState(false);
+    const user  = useUser();
+
+
+    const getChatId = (uid1, uid2) => {
+        return uid1 < uid2 ? `${uid1}_${uid2}` : `${uid2}_${uid1}`;
+    }
+
+
+
+    const handleDeleteFriend = () => {
+        Alert.alert("Vahvista", "Haluatko varmasti poistaa ystävän?", [
+            { text: "Peruuta", style: "cancel" },
+            { text: "Kyllä", style: "destructive", onPress: confirmDeleteFriend },
+        ]);
+    }
+
+    const confirmDeleteFriend = async () => {
+        if (!user) {
+            Alert.alert("Virhe", "Käyttäjä ei ole kirjautunut sisään.");
+            return;
+        }
+        try {
+            setIsDeleting(true);
+
+            // Delete friend from current user's friend list
+            const UsersRef = doc(firestore, USERS, user.uid, FRIENDS, friendId);
+            await deleteDoc(UsersRef);
+
+            // Delete current user from friend's friend list
+            const friendsRef = doc(firestore, USERS, friendId, FRIENDS, user.uid);
+            await deleteDoc(friendsRef);
+
+            //Delete chat between users
+            const chatId = getChatId(user.uid, friendId);
+
+            const chatRef = doc(firestore, PRIVATECHATS, chatId);
+
+            const currentUserChatRef = doc(firestore, USERS, user.uid, USERSPRIVATECHATS, chatId);
+            const friendChatRef = doc(firestore, USERS, friendId, USERSPRIVATECHATS, chatId);
+            console.log("Deleting chat with ID:", chatId);
+
+            await deleteDoc(chatRef);
+            await deleteDoc(currentUserChatRef);
+            await deleteDoc(friendChatRef);
+
+
+            setIsDeleting(false);
+            Alert.alert("Ystävä poistettu", "Ystävä on onnistuneesti poistettu.", [{ text: "OK" , onPress: () => {if (onRemoved) onRemoved()}}], { cancelable: true });
+
+
+        }catch (error) {
+            console.error("Error deleting friend:", error);
+            Alert.alert("Virhe", "Ystävän poisto epäonnistui.");
+            setIsDeleting(false);
+        }
+    }
+    return (
+        <TouchableOpacity onPress={handleDeleteFriend} disabled={isDeleting} style={{ padding: 10, backgroundColor: "#ff4d4d", borderRadius: 5 }}>
+            <Ionicons name="trash" size={24} color={isDeleting ? '#0b0a0a' : '#fff'} />
+        </TouchableOpacity>
+    )
+}

--- a/src/components/FriendRequestButton.js
+++ b/src/components/FriendRequestButton.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, use} from "react";
+import React, { useState, useEffect} from "react";
 import { TouchableOpacity, Text, Alert } from "react-native";
 import { firestore, USERS, FRIENDREQUESTS, doc, collection, onSnapshot, getDoc, serverTimestamp, setDoc} from "../firebase/config";
 import { Ionicons } from "@expo/vector-icons";
@@ -8,10 +8,11 @@ export default function FriendRequestButton({ user, targetUserId, friendsList =[
     const [isFriend, setIsFriend] = useState(false);
 
     useEffect(() => {
-        if (!user || !targetUserId) return;
-        const friendsRef = doc(firestore, USERS, user.uid, "friends", targetUserId);
+        if (!user?.uid || !targetUserId) return;
+        const friendsRef = doc(firestore, USERS, user.uid, "friends", targetUserId)
         const unsubscribe = onSnapshot(friendsRef, (snapshot) => {
-            setIsFriend(snapshot.exists());
+            setIsFriend(snapshot.exists()),
+            (error) => console.error("Error checking friendship status:", error);
         });
         return () => unsubscribe();
     }, [user, targetUserId]);
@@ -23,6 +24,11 @@ export default function FriendRequestButton({ user, targetUserId, friendsList =[
 
     // fuction to handle friend requests 
     const handleFriendRequest = async () => {
+
+        if (user.uid === targetUserId) {
+            Alert.alert("Virhe", "Et voi lähettää kaveripyyntöä itsellesi.");
+            return;
+        }
 
     try {
         const targetUserSnap = await getDoc(doc(firestore, USERS, targetUserId));
@@ -43,7 +49,7 @@ export default function FriendRequestButton({ user, targetUserId, friendsList =[
         }
         const requestDocRef = doc(currentUserRequestsRef)
         await setDoc(requestDocRef, requestData)
-        await setDoc(doc(targetUserRequestsRef, requestDocRef.id), requestData)
+        await setDoc(doc(targetUserRequestsRef, requestDocRef.id), {...requestData, read: false,})
 
         Alert.alert("Pyyntö lähetetty", `Kaveripyyntö lähetetty käyttäjälle ${targetUserData.firstName} ${targetUserData.lastName}`);
     } catch (error) {
@@ -66,6 +72,7 @@ export default function FriendRequestButton({ user, targetUserId, friendsList =[
     return (
         <TouchableOpacity
             onPress={handleFriendRequest}   
+            disabled={!!request?.status}
             style={{
                 backgroundColor: "#e7e7e7",
                 paddingHorizontal: 10,

--- a/src/components/NavbarBottom.js
+++ b/src/components/NavbarBottom.js
@@ -1,13 +1,16 @@
 import React from "react";
-import { View, TouchableOpacity, StyleSheet } from "react-native";
+import { View, TouchableOpacity, StyleSheet, Text } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import useUnreadCounts from "../hooks/useUnreadCounts";
+
 
 export default function NavbarBottom() {
   const navigation = useNavigation();
   const route = useRoute();
   const fit = useSafeAreaInsets();
+  const { unreadChatsCount } = useUnreadCounts();
 
   const isHomeScreen = route.name === "Home"
 
@@ -33,7 +36,17 @@ export default function NavbarBottom() {
       <TouchableOpacity 
         style={styles.buttonContainer}
         onPress={() => navigation.navigate("PrivaChats")}>
-        <MaterialIcons name="chat" size={32} color={route.name === "PrivaChats" ? "#FB7318" : "#999"} />
+        <View style={{ position: "relative" }}>
+          <MaterialIcons name="chat" size={32} color={route.name === "PrivaChats" ? "#FB7318" : "#999"} />
+
+          {unreadChatsCount > 0 && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>
+                {unreadChatsCount > 9 ? "9+" : unreadChatsCount}
+              </Text>
+            </View>
+          )}
+        </View>
       </TouchableOpacity>
 
 
@@ -70,6 +83,24 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  badge: {
+    position: "absolute",
+    top: -5,
+    right: -5,
+    backgroundColor: "red",
+    borderRadius: 10,
+    minWidth: 18,
+    height: 18,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 4
 
+  },
+
+  badgeText: {
+    color: "white", 
+    fontSize: 10, 
+    fontWeight: "bold" 
+  },
 
 });

--- a/src/components/NavbarTop.js
+++ b/src/components/NavbarTop.js
@@ -1,47 +1,46 @@
-import React from "react";
-import { useState, useEffect } from "react";
-import { View, TouchableOpacity, StyleSheet } from "react-native";
+import React, { useState, useEffect } from "react";
+import { View, TouchableOpacity, StyleSheet, Text } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import UserAvatar from "./UserAvatar.js";
 import { useUser } from "../context/UserContext";
-import { firestore, USERS,onSnapshot,doc } from "../firebase/config.js";
+import { firestore, USERS, onSnapshot,doc ,} from "../firebase/config.js";
+import useUnreadCounts from "../hooks/useUnreadCounts.js";
 
 export default function NavbarTop({ showBack = false, showProfile = false, showNotifications = false  }) {
-    const navigation = useNavigation();
-    const fit = useSafeAreaInsets();
-    const user= useUser();
+  const navigation = useNavigation();
+  const fit = useSafeAreaInsets();
+  const user= useUser();
+  const { totalNotifications } = useUnreadCounts();
 
-    const [myAvatar, setMyAvatar] = useState({
-          avatarSeed: "",
-          avatarStyle: "",
+  const [myAvatar, setMyAvatar] = useState({
+        avatarSeed: "",
+        avatarStyle: "",
+      });
+
+  // Listen for changes in the user's avatar data to update the avatar in real-time
+  useEffect(() => {
+    if (!user?.uid) return;
+    const userRef = doc(firestore, USERS, user.uid);
+    
+    const unsubscribe = onSnapshot(userRef, (userSnap) => { 
+        if (userSnap.exists()) {
+          const data = userSnap.data();
+
+        setMyAvatar({
+        avatarSeed: data.avatarSeed || "",
+        avatarStyle: data.avatarStyle || "",
         });
+    }
 
-         useEffect(() => {
-                    
-                        if (!user?.uid) return;
-        
-                        
-                        const userRef = doc(firestore, USERS, user.uid);
-                        
-                        const unsubscribe = onSnapshot(userRef, (userSnap) => { 
-                            if (userSnap.exists()) {
-                              const data = userSnap.data();
-        
-                            setMyAvatar({
-                            avatarSeed: data.avatarSeed || "",
-                            avatarStyle: data.avatarStyle || "",
-                            });
-                        }
+    }, (error) =>{
+        console.log("Virhe avatarin haussa:", error.message);
+        }
+      );
+    return unsubscribe;
+  }, [user]);    
 
-                  }, (error) =>{
-                        console.log("Virhe avatarin haussa:", error.message);
-                        }
-                      );
-                    return unsubscribe;
-                    }, [user]);    
-                    
 
   return (
     <View style={[styles.container, {paddingTop: fit.top +15 }]}>
@@ -53,9 +52,19 @@ export default function NavbarTop({ showBack = false, showProfile = false, showN
         <Ionicons name="arrow-back" size={30} />
       </TouchableOpacity>
       ) : showNotifications ? (
-        <TouchableOpacity onPress={() => navigation.navigate("Notifications")}
-        >
+        <TouchableOpacity onPress={() => navigation.navigate("Notifications")}>
+
+          <View style={{ position: "relative" }}>
           <Ionicons name="notifications-circle-outline" size={40} />
+
+          {totalNotifications > 0 && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>
+                {totalNotifications > 9 ? "9+" : totalNotifications}
+              </Text>
+            </View>
+          )}
+          </View>
         </TouchableOpacity>
       ) : null}
       </View>
@@ -82,5 +91,24 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingHorizontal: 15,
     backgroundColor: "#fff",
+  },
+  badge: {
+    position: "absolute",
+    top: -5,
+    right: -5,
+    backgroundColor: "red",
+    borderRadius: 10,
+    minWidth: 18,
+    height: 18,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 4
+
+  },
+
+  badgeText: {
+    color: "white", 
+    fontSize: 10, 
+    fontWeight: "bold" 
   },
 });

--- a/src/hooks/useUnreadCounts.js
+++ b/src/hooks/useUnreadCounts.js
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from "react";
+import { useUser } from "../context/UserContext";
+import { firestore, USERS, onSnapshot, collection, FRIENDREQUESTS, USERSPRIVATECHATS} from "../firebase/config.js";
+
+
+
+export default function useUnreadCounts() {
+    const user = useUser();  
+    const [unreadNotificationsCount, setUnreadNotificationsCount] = useState(0);
+    const [unReadFriendRequestsCount, setUnReadFriendRequestsCount] = useState(0);
+    const [unreadChatsCount, setUnreadChatsCount] = useState(0);
+
+
+
+    // Listen for changes in the user's notifications to update the unread count in real-time
+    useEffect(() => {
+    if (!user?.uid) return;
+    const notificationsRef = collection(firestore, USERS, user.uid, "notifications")
+
+    const unsubscribe = onSnapshot(notificationsRef, (snapshot) => {
+        const unreadCount = snapshot.docs.filter(doc => !doc.data().read).length
+        setUnreadNotificationsCount(unreadCount)
+    });
+    return () => unsubscribe()
+    }, [user]);
+
+
+    // Listen for changes in the user's friend requests to update the unread count in real-time
+    useEffect(() => {
+    if (!user?.uid) return;
+    const friendRequestsRef = collection(firestore, USERS, user.uid, FRIENDREQUESTS)
+    const unsubscribe = onSnapshot(friendRequestsRef, (snapshot) => {
+        const unReadCount = snapshot.docs.filter(doc => doc.data().status === "pending" && !doc.data().read && doc.data().toUserId === user.uid).length
+        setUnReadFriendRequestsCount(unReadCount)
+    });
+    return () => unsubscribe()
+    }, [user]);
+    
+    
+  //Checks unread chats
+  useEffect(() => {
+    if (!user) return;
+
+    const chatsRef = collection(firestore, USERS, user.uid, USERSPRIVATECHATS);
+    const unsubscribe = onSnapshot(chatsRef, (snapshot) => {
+      const chats = snapshot.docs.filter(doc => doc.data().unReadMessages).length;
+      setUnreadChatsCount(chats);
+    });
+
+    return () => unsubscribe();
+  }, [user]);
+
+  return { unreadNotificationsCount, unReadFriendRequestsCount, unreadChatsCount, totalNotifications: unreadNotificationsCount + unReadFriendRequestsCount };
+}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { View, Text, TouchableOpacity,Image, TextInput, Alert } from "react-native";
 import { useUser } from "../context/UserContext.js";
 import { useNavigation } from "@react-navigation/native";
-import { firestore, USERS, FRIENDREQUESTS, doc, getDoc, collection, onSnapshot, addDoc, serverTimestamp, setDoc} from "../firebase/config";
+import { firestore, USERS, FRIENDREQUESTS, doc, getDoc, collection, onSnapshot, addDoc, serverTimestamp, setDoc, USERSPRIVATECHATS} from "../firebase/config";
 import styles from "../styles/Home.js";
 import { Ionicons } from "@expo/vector-icons";
 import Logo from "../../assets/Logo.png";
@@ -86,12 +86,15 @@ export default function HomeScreen() {
     return () => unsubscribe();
   }, [user]);
 
+
+
+  // Clears the search results and query when the screen is unfocused to prevent showing old search results when user returns to the screen
   useFocusEffect(
     useCallback(() => {
-      // Kun screen tulee fokukseen → ei tehdä mitään
+      // Screen focused 
 
       return () => {
-        // Kun poistutaan screeniltä → tyhjennetään
+        // Screen unfocused, clear search results and query
         setSearchQuery("");
         setFilteredUsers([]);
       };
@@ -110,23 +113,24 @@ export default function HomeScreen() {
     }
     const formattedQuery = query.toLowerCase()
 
-  let results = [];
+    let results = [];
 
-  if (formattedQuery.length === 1) {
-    results = listOfUsers.filter(
-      (user) =>
-        user.firstName?.toLowerCase().startsWith(formattedQuery) ||
-        user.lastName?.toLowerCase().startsWith(formattedQuery)
-    );
-  } else {
-    results = listOfUsers.filter(
-      (user) =>
-        user.firstName?.toLowerCase().includes(formattedQuery) ||
-        user.lastName?.toLowerCase().includes(formattedQuery)
-    );
-  }
-    setFilteredUsers(results)
+    if (formattedQuery.length === 1) {
+      results = listOfUsers.filter(
+        (user) =>
+          user.firstName?.toLowerCase().startsWith(formattedQuery) ||
+          user.lastName?.toLowerCase().startsWith(formattedQuery)
+      );
+    } else {
+      results = listOfUsers.filter(
+        (user) =>
+          user.firstName?.toLowerCase().includes(formattedQuery) ||
+          user.lastName?.toLowerCase().includes(formattedQuery)
+      );
+    }
+      setFilteredUsers(results)
   };
+
 
   if (isLoading) {
     return (<Loading />);
@@ -138,6 +142,8 @@ export default function HomeScreen() {
       <View style={styles.logoContainer}>
         <Image source={Logo} style={styles.logo} />
       </View>
+
+
 
       <Text style={styles.helloUser}>Tervetuloa takaisin {firstName}!</Text>
 

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -10,6 +10,7 @@ import FontAwesome5 from '@expo/vector-icons/FontAwesome5'
 import Divider from "../components/Divider.js";
 import FriendRequestButton from "../components/FriendRequestButton.js";
 import Loading from "../components/Loading.js";
+import DeleteFriend from "../components/DeleteFriend.js";
 
 export default function ProfileScreen() {
   const navigation = useNavigation();
@@ -295,24 +296,13 @@ if (isLoading) {
               return (
                 <View style={styles.friendRow}>
                   <View style={styles.friendInfo}>
-                <Text style={styles.friendName}>{item.name}</Text>
-                  <Text style={styles.friendDate}>
-                    ystävä alkaen: {date}
-                </Text>
+                    <Text style={styles.friendName}>{item.name}</Text>
+                      <Text style={styles.friendDate}>
+                        ystävä alkaen: {date}
+                    </Text>
                   </View>
 
-                  <TouchableOpacity
-                style={styles.deleteButton}
-                onPress={() => Alert.alert("Poista ystävä", "Haluatko varmasti poistaa tämän ystävän?", [
-                  {
-                    text: "Kyllä",
-                    onPress: () => {} // Poista ystävä logiikka tähän
-                  },
-                  { text: "Ei" }
-                ])}
-              >
-                <Ionicons name="trash" size={24} color="#0b0a0a" />
-              </TouchableOpacity>
+                  <DeleteFriend friendId={item.id} onRemoved={fetchUserData} />
                 </View>
               );
             }}


### PR DESCRIPTION
Kotinäytöllä näkyy nyt montako lukematonta ilmoitusta on ilmoituksissa ja chatissa.
Näkyy numerona 0-9 sitten 9+. Tätä varten tehty hookki userUnreadCounts, tuli vähän selkeämmäksi kun nuo oli kaikki omassa jutussaan. Tieto onko noita lukemattomia menee sitten topNaviin tai bottom naviin. Niissä myös kattelin turhia importteja pois ja korjailin rivitystä/ välejä, mutta muuten en koskenut noihin siä oleviin juttuihi :)

Kaverin poisto tehty. Tämä poistaa kavein molempien kaverilistalta ja yhteisen keskustelun. Tähän tehty DeleteFriend komponentti, jos halutaan laittaa kaverin poisto myös profiilin tarkasteluun. 


Lisätty myös kaveripyynnön lähettämiseen tarkistus että käyttäjä jolle pyyntö lähetetään ei ole sinä itse, kun sitä ei muualla tarkisteta. Lisäksi laitettu puuttuva read: false kenttä vastaanottajan dokumenttiin.

