### PR TITLE
ryhmän muokkaus

### DIFF
--- a/src/components/DeleteFriend.js
+++ b/src/components/DeleteFriend.js
@@ -65,8 +65,8 @@ export default function DeleteFriend({friendId, onRemoved}) {
         }
     }
     return (
-        <TouchableOpacity onPress={handleDeleteFriend} disabled={isDeleting} style={{ padding: 10, backgroundColor: "#ff4d4d", borderRadius: 5 }}>
-            <Ionicons name="trash" size={24} color={isDeleting ? '#0b0a0a' : '#fff'} />
+        <TouchableOpacity onPress={handleDeleteFriend} disabled={isDeleting} style={{ padding: 10, backgroundColor: "#ff4d4d", borderRadius: 12 }}>
+            <Ionicons name="trash" size={20} color={isDeleting ? '#0b0a0a' : '#fff'} />
         </TouchableOpacity>
     )
 }

--- a/src/components/GroupAvatarPicker.js
+++ b/src/components/GroupAvatarPicker.js
@@ -40,6 +40,7 @@ export default function GroupAvatarPicker({
   setAvatarStyle,
   setAvatarSeed,
   groupName,
+  size = 120,
 }) {
   const [modalVisible, setModalVisible] = useState(false);
   const [tempStyle, setTempStyle] = useState(avatarStyle || "1");
@@ -71,7 +72,7 @@ export default function GroupAvatarPicker({
         seed: avatarSeed,
         style: avatarStyle || "1",
         name: groupName || "Group",
-        size: 120,
+        size,
       })
     : null;
 
@@ -89,14 +90,14 @@ export default function GroupAvatarPicker({
       <View style={{ position: "relative" }}>
         {currentAvatarUrl && (
             <View style={{ 
-                width: 120,
-                height: 120,
+                width: size,
+                height: size,
                 borderRadius: 60,
                 overflow: "hidden",
                 marginBottom: 12,
              }}>
 
-          <SvgUri uri={currentAvatarUrl} width={120} height={120} />
+          <SvgUri uri={currentAvatarUrl} width={size} height={size} />
         </View>
         )}
 
@@ -137,7 +138,7 @@ export default function GroupAvatarPicker({
           <View
             style={{
               width: "85%",
-              maxHeight: "80%",
+              maxHeight: "85%",
               backgroundColor: "#fff",
               borderRadius: 20,
               padding: 20,
@@ -207,7 +208,7 @@ export default function GroupAvatarPicker({
                             overflow: "hidden",
                         }}>
 
-                      <SvgUri uri={previewAvatarUrl} width={120} height={120} />
+                      <SvgUri uri={previewAvatarUrl} width={70} height={70} />
                       </View>
 
                       <Text

--- a/src/components/NavbarTop.js
+++ b/src/components/NavbarTop.js
@@ -8,7 +8,11 @@ import { useUser } from "../context/UserContext";
 import { firestore, USERS, onSnapshot,doc ,} from "../firebase/config.js";
 import useUnreadCounts from "../hooks/useUnreadCounts.js";
 
-export default function NavbarTop({ showBack = false, showProfile = false, showNotifications = false  }) {
+export default function NavbarTop({ 
+  showBack = false, 
+  showProfile = false, 
+  showNotifications = false,
+}) {
   const navigation = useNavigation();
   const fit = useSafeAreaInsets();
   const user= useUser();

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -17,6 +17,7 @@ import Notifications from "../screens/Notifications";
 import SpecificGroupChat from "../screens/SpecificGroupChat";
 import EditProfileScreen from "../screens/EditProfileScreen";
 import ChangePasswordScreen from "../screens/ChangePasswordScreen";
+import EditGroupScreen from "../screens/EditGroupScreen";
 
 import NavbarTop from "../components/NavbarTop";
 import NavbarBottom from "../components/NavbarBottom";
@@ -36,6 +37,7 @@ export default function AppNavigator() {
             showBack={options.showBack}
             showProfile={options.showProfile}
             showNotifications={options.showNotifications}
+            groupMenu={props.route?.params?.groupMenu}
           />
           <View style={styles.content}>
             <Component {...props} />
@@ -124,6 +126,14 @@ export default function AppNavigator() {
                   showBottom: false,
                 })}
               />
+
+              <Stack.Screen
+              name="EditGroup"
+              component={withNavBars(EditGroupScreen, {
+                showBack: true,
+                showBottom: false,
+              })}
+            />
             </>
           ) : (
             <>

--- a/src/screens/EditGroupScreen.js
+++ b/src/screens/EditGroupScreen.js
@@ -1,0 +1,629 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Alert,
+  Modal,
+  FlatList,
+  ScrollView,
+} from "react-native";
+import { useRoute, useNavigation } from "@react-navigation/native";
+import { Ionicons } from "@expo/vector-icons";
+
+import { useUser } from "../context/UserContext.js";
+import UserAvatar from "../components/UserAvatar.js";
+import Divider from "../components/Divider.js";
+import GroupAvatarPicker from "../components/GroupAvatarPicker.js";
+import styles from "../styles/EditGroup.js";
+
+import {
+  firestore,
+  USERS,
+  FRIENDS,
+  doc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  setDoc,
+  serverTimestamp,
+} from "../firebase/config.js";
+
+import { collection, getDocs } from "firebase/firestore";
+
+export default function EditGroupScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const user = useUser();
+
+  const { groupId, isAdmin } = route.params;
+
+  const [groupData, setGroupData] = useState(null);
+  const [groupName, setGroupName] = useState("");
+  const [description, setDescription] = useState("");
+  const [avatarSeed, setAvatarSeed] = useState("");
+  const [avatarStyle, setAvatarStyle] = useState("1");
+
+  const [members, setMembers] = useState([]);
+  const [friendsList, setFriendsList] = useState([]);
+  const [selectedFriends, setSelectedFriends] = useState([]);
+  const [membersModalVisible, setMembersModalVisible] = useState(false);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchGroupData = async () => {
+    try {
+      const groupRef = doc(firestore, "groups", groupId);
+      const groupSnap = await getDoc(groupRef);
+
+      if (!groupSnap.exists()) {
+        Alert.alert("Virhe", "Ryhmää ei löytynyt.");
+        navigation.goBack();
+        return;
+      }
+
+      const data = groupSnap.data();
+
+      setGroupData(data);
+      setGroupName(data.groupName || "");
+      setDescription(data.desc || "");
+      setAvatarSeed(data.avatarSeed || "");
+      setAvatarStyle(
+        data.avatarStyle || "1"
+      );
+    } catch (error) {
+      console.log("Virhe ryhmän tietojen haussa:", error);
+      Alert.alert("Virhe", "Ryhmän tietojen haku epäonnistui.");
+    }
+  };
+
+  const fetchMembers = async () => {
+    try {
+      const membersRef = collection(firestore, "groups", groupId, "members");
+      const membersSnap = await getDocs(membersRef);
+
+      const membersData = await Promise.all(
+        membersSnap.docs.map(async (memberDoc) => {
+          const memberId = memberDoc.id;
+          const memberInfo = memberDoc.data();
+
+          try {
+            const userRef = doc(firestore, USERS, memberId);
+            const userSnap = await getDoc(userRef);
+
+            if (userSnap.exists()) {
+              const userData = userSnap.data();
+
+              return {
+                id: memberId,
+                role: memberInfo.role || "member",
+                name: `${userData.firstName || "Tuntematon"} ${userData.lastName || ""}`.trim(),
+                avatarSeed: userData.avatarSeed || "",
+                avatarStyle:
+                  userData.avatarStyle === "fun emoji"
+                    ? "fun-emoji"
+                    : userData.avatarStyle || "fun-emoji",
+              };
+            }
+
+            return {
+              id: memberId,
+              role: memberInfo.role || "member",
+              name: "Tuntematon käyttäjä",
+              avatarSeed: "",
+              avatarStyle: "fun-emoji",
+            };
+          } catch (error) {
+            console.log("Virhe jäsenen haussa:", error);
+            return {
+              id: memberId,
+              role: memberInfo.role || "member",
+              name: "Tuntematon käyttäjä",
+              avatarSeed: "",
+              avatarStyle: "fun-emoji",
+            };
+          }
+        })
+      );
+
+      setMembers(membersData);
+    } catch (error) {
+      console.log("Virhe jäsenten haussa:", error);
+      Alert.alert("Virhe", "Jäsenten haku epäonnistui.");
+    }
+  };
+
+  const fetchFriends = async () => {
+    if (!user?.uid) return;
+
+    try {
+      const friendsRef = collection(firestore, USERS, user.uid, FRIENDS);
+      const friendsSnap = await getDocs(friendsRef);
+
+      const existingMemberIds = new Set(members.map((member) => member.id));
+
+      const friendsData = await Promise.all(
+        friendsSnap.docs.map(async (friendDoc) => {
+          const friendId = friendDoc.id;
+
+          try {
+            const userRef = doc(firestore, USERS, friendId);
+            const userSnap = await getDoc(userRef);
+
+            if (!userSnap.exists()) return null;
+
+            const userData = userSnap.data();
+
+            return {
+              id: friendId,
+              name: `${userData.firstName || "Tuntematon"} ${userData.lastName || ""}`.trim(),
+              avatarSeed: userData.avatarSeed || "",
+              avatarStyle:
+                userData.avatarStyle === "fun emoji"
+                  ? "fun-emoji"
+                  : userData.avatarStyle || "fun-emoji",
+              alreadyMember: existingMemberIds.has(friendId),
+            };
+          } catch (error) {
+            console.log("Virhe kaverin haussa:", error);
+            return null;
+          }
+        })
+      );
+
+      setFriendsList(friendsData.filter(Boolean));
+    } catch (error) {
+      console.log("Virhe kaverilistan haussa:", error);
+      Alert.alert("Virhe", "Kaverilistan haku epäonnistui.");
+    }
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      await fetchGroupData();
+      await fetchMembers();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [groupId]);
+
+  useEffect(() => {
+    if (!loading) {
+      fetchFriends();
+    }
+  }, [loading, members.length]);
+
+  const toggleFriendSelection = (friendId) => {
+    setSelectedFriends((prev) =>
+      prev.includes(friendId)
+        ? prev.filter((id) => id !== friendId)
+        : [...prev, friendId]
+    );
+  };
+
+  const handleSaveGroup = async () => {
+    if (!groupName.trim()) {
+      Alert.alert("Virhe", "Ryhmän nimi ei voi olla tyhjä.");
+      return;
+    }
+
+    try {
+      setSaving(true);
+
+      const groupRef = doc(firestore, "groups", groupId);
+
+      await updateDoc(groupRef, {
+        groupName: groupName.trim(),
+        desc: description.trim(),
+        avatarSeed: avatarSeed || "",
+        avatarStyle: avatarStyle || "1",
+      });
+
+       for (const member of members) {
+      const userGroupRef = doc(
+        firestore,
+        "user",
+        member.id,
+        "user-groups",
+        groupId
+      );
+
+      await setDoc(
+        userGroupRef,
+        {
+          groupName: groupName.trim(),
+          description: description.trim(),
+          avatarSeed: avatarSeed || "",
+          avatarStyle: avatarStyle || "1",
+        },
+        { merge: true }
+      );
+    }
+
+      Alert.alert("Onnistui", "Ryhmän tiedot päivitetty.");
+    } catch (error) {
+      console.log("Virhe ryhmän tallennuksessa:", error);
+      Alert.alert("Virhe", "Ryhmän tietojen tallennus epäonnistui.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAddSelectedMembers = async () => {
+    if (selectedFriends.length === 0) {
+      Alert.alert("Huom", "Valitse vähintään yksi käyttäjä.");
+      return;
+    }
+
+    try {
+        const currentGroupName = groupName.trim() || groupData?.groupName || "Nimetön ryhmä";
+        const currentDescription = description.trim() || groupData?.desc || "";
+
+      for (const friendId of selectedFriends) {
+        // 1. Lisää jäsen ryhmän members-subcollectioniin
+        const memberRef = doc(firestore, "groups", groupId, "members", friendId);
+
+        await setDoc(
+          memberRef,
+          {
+            role: "member",
+            addedAt: serverTimestamp(),
+            addedBy: user.uid,
+          },
+          { merge: true }
+        );
+      
+       // 2. Lisää ryhmä myös käyttäjän omaan user-groups-listaan
+      const userGroupRef = doc(
+        firestore,
+        "user",
+        friendId,
+        "user-groups",
+        groupId
+      );
+
+      await setDoc(
+        userGroupRef,
+        {
+          groupName: currentGroupName,
+          description: currentDescription,
+          joined: serverTimestamp(),
+          role: "member",
+          avatarSeed: avatarSeed || groupData?.avatarSeed || "",
+          avatarStyle: avatarStyle || groupData?.avatarStyle || "1",
+        },
+        { merge: true }
+      );
+    }
+
+      Alert.alert("Onnistui", "Jäsenet lisätty ryhmään.");
+      setSelectedFriends([]);
+      setMembersModalVisible(false);
+
+      await fetchMembers();
+      await fetchFriends();
+    } catch (error) {
+      console.log("Virhe jäsenten lisäyksessä:", error);
+      Alert.alert("Virhe", "Jäsenten lisääminen epäonnistui.");
+    }
+  };
+
+
+  const handleRemoveMember = (member) => {
+        if (member.id === user?.uid) {
+            Alert.alert("Et voi poistaa itseäsi ryhmästä.");
+            return;
+        }
+
+        Alert.alert(
+            "Poista jäsen",
+            `Haluatko varmasti poistaa käyttäjän ${member.name} ryhmästä?`,
+            [
+            { text: "Peruuta", style: "cancel" },
+            {
+                text: "Poista",
+                style: "destructive",
+                onPress: async () => {
+                try {
+                    // 1. Poista jäsen ryhmän members-subcollectionista
+                    await deleteDoc(doc(firestore, "groups", groupId, "members", member.id));
+
+                    // 2. Poista ryhmä käyttäjän omasta user-groups-listasta
+                    await deleteDoc(doc(firestore, "user", member.id, "user-groups", groupId));
+
+                    // 3. Päivitä paikallinen state heti
+                    setMembers((prev) => prev.filter((m) => m.id !== member.id));
+
+                    Alert.alert("Jäsen poistettu ryhmästä.");
+                } catch (error) {
+                    console.log("Virhe jäsenen poistossa:", error);
+                    Alert.alert("Virhe", "Jäsenen poistaminen epäonnistui.");
+                }
+                },
+            },
+            ]
+        );
+        };
+
+  const handleDeleteGroup = () => {
+    Alert.alert(
+      "Poista ryhmä",
+      "Haluatko varmasti poistaa koko ryhmän? Tätä ei voi perua.",
+      [
+        { text: "Peruuta", style: "cancel" },
+        {
+          text: "Poista",
+          style: "destructive",
+          onPress: async () => {
+            try {
+                // 1. Poista ryhmä kaikilta jäseniltä user-groups-listasta
+              for (const member of members) {
+                await deleteDoc(
+                    doc(firestore, "user", member.id, "user-groups", groupId)
+                );
+              }
+
+                 // 2. Poista members-subcollectionin dokumentit
+                const membersRef = collection(firestore, "groups", groupId, "members");
+                const membersSnap = await getDocs(membersRef);
+
+                 for (const memberDoc of membersSnap.docs) {
+                 await deleteDoc(memberDoc.ref);
+            }
+
+                // 3. Poista messages-subcollectionin dokumentit
+                 const messagesRef = collection(firestore, "groups", groupId, "messages");
+                 const messagesSnap = await getDocs(messagesRef);
+
+                 for (const messageDoc of messagesSnap.docs) {
+                 await deleteDoc(messageDoc.ref);
+            }
+                // 4. Lopuksi poista itse ryhmän dokumentti
+              await deleteDoc (doc(firestore, "groups", groupId));
+              
+              Alert.alert("Ryhmä poistettu");
+              navigation.goBack();
+            } catch (error) {
+              console.log("Virhe ryhmän poistossa:", error);
+              Alert.alert("Virhe", "Ryhmän poistaminen epäonnistui.");
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleLeaveGroup = () => {
+        Alert.alert(
+            "Poistu ryhmästä",
+            "Haluatko varmasti poistua tästä ryhmästä?",
+            [
+            { text: "Peruuta", style: "cancel" },
+            {
+                text: "Poistu",
+                style: "destructive",
+                onPress: async () => {
+                try {
+                    await deleteDoc(doc(firestore, "groups", groupId, "members", user.uid));
+                    await deleteDoc(doc(firestore, "user", user.uid, "user-groups", groupId));
+
+                    Alert.alert("Poistuit ryhmästä");
+                    navigation.navigate("GroupsScreen");
+                } catch (error) {
+                    console.log("Virhe ryhmästä poistumisessa:", error);
+                    Alert.alert("Virhe", "Ryhmästä poistuminen epäonnistui.");
+                }
+                },
+            },
+            ]
+        );
+        };
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <Text>Ladataan ryhmän tietoja...</Text>
+      </View>
+    );
+  }
+
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>
+        {isAdmin ? "Ryhmän asetukset" : "Lisää jäseniä"}
+      </Text>
+
+      {isAdmin && (
+        <>
+          <View style={styles.section}>
+            <Text style={styles.label}>Profiilikuva</Text>
+
+            <GroupAvatarPicker
+                avatarStyle={avatarStyle}
+                avatarSeed={avatarSeed}
+                setAvatarStyle={setAvatarStyle}
+                setAvatarSeed={setAvatarSeed}
+                groupName={groupName}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.label}>Ryhmän nimi</Text>
+            <TextInput
+              value={groupName}
+              onChangeText={setGroupName}
+              style={styles.input}
+              placeholder="Anna ryhmän nimi"
+            />
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.label}>Kuvaus</Text>
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              style={[styles.input, styles.multilineInput]}
+              placeholder="Kirjoita ryhmän kuvaus"
+              multiline
+            />
+          </View>
+
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={handleSaveGroup}
+            disabled={saving}
+          >
+            <Text style={styles.primaryButtonText}>
+              {saving ? "Tallennetaan..." : "Tallenna muutokset"}
+            </Text>
+          </TouchableOpacity>
+        </>
+      )}
+
+      <Divider />
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Jäsenet ({members.length})</Text>
+
+        {members.map((member) => (
+          <View key={member.id} style={styles.memberRow}>
+            <View style={styles.memberLeft}>
+              <UserAvatar
+                avatarSeed={member.avatarSeed}
+                avatarStyle={member.avatarStyle}
+                size={42}
+              />
+              <View style={{ marginLeft: 12 }}>
+                <Text style={styles.memberName}>{member.name}</Text>
+                <Text style={styles.memberRole}>
+                  {member.role === "admin" ? "Admin" : "Jäsen"}
+                </Text>
+              </View>
+            </View>
+
+            {isAdmin && member.id !== user?.uid && (
+                <TouchableOpacity
+                    onPress={() => handleRemoveMember(member)}
+                    style={styles.removeMemberButton}
+                >
+                    <Text style={styles.removeMemberButtonText}>Poista</Text>
+                </TouchableOpacity>
+                )}
+
+          </View>
+        ))}
+      </View>
+
+      <TouchableOpacity
+        style={styles.primaryButton}
+        onPress={() => setMembersModalVisible(true)}
+      >
+        <Text style={styles.primaryButtonText}>Lisää jäseniä</Text>
+      </TouchableOpacity>
+
+      {!isAdmin && (
+        <TouchableOpacity
+            style={styles.leaveButton}
+            onPress={handleLeaveGroup}
+        >
+            <Text style={styles.leaveButtonText}>Poistu ryhmästä</Text>
+        </TouchableOpacity>
+        )}
+
+      {isAdmin && (
+        <TouchableOpacity
+          style={styles.deleteButton}
+          onPress={handleDeleteGroup}
+        >
+          <Text style={styles.deleteButtonText}>Poista koko ryhmä</Text>
+        </TouchableOpacity>
+      )}
+
+      <Modal
+        visible={membersModalVisible}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setMembersModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>Valitse lisättävät jäsenet</Text>
+
+            <FlatList
+              data={friendsList}
+              keyExtractor={(item) => item.id}
+              renderItem={({ item }) => {
+                const selected = selectedFriends.includes(item.id);
+
+                return (
+                  <TouchableOpacity
+                    style={[
+                      styles.friendRow,
+                      item.alreadyMember && styles.disabledFriendRow,
+                    ]}
+                    disabled={item.alreadyMember}
+                    onPress={() => toggleFriendSelection(item.id)}
+                  >
+                    <View style={styles.memberLeft}>
+                      <UserAvatar
+                        avatarSeed={item.avatarSeed}
+                        avatarStyle={item.avatarStyle}
+                        size={42}
+                      />
+
+                      <View style={{ marginLeft: 12 }}>
+                        <Text style={styles.memberName}>{item.name}</Text>
+                        <Text style={styles.memberRole}>
+                          {item.alreadyMember ? "Jo jäsen" : "Kaveri"}
+                        </Text>
+                      </View>
+                    </View>
+
+                    <Ionicons
+                      name={
+                        item.alreadyMember
+                          ? "checkmark-circle"
+                          : selected
+                          ? "checkbox"
+                          : "square-outline"
+                      }
+                      size={24}
+                      color={item.alreadyMember || selected ? "#f17a0a" : "#666"}
+                    />
+                  </TouchableOpacity>
+                );
+              }}
+              ListEmptyComponent={
+                <Text style={{ textAlign: "center", marginTop: 20 }}>
+                  Kaverilistalla ei ole lisättäviä käyttäjiä.
+                </Text>
+              }
+            />
+
+            <TouchableOpacity
+              style={styles.primaryButton}
+              onPress={handleAddSelectedMembers}
+            >
+              <Text style={styles.primaryButtonText}>Lisää valitut</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => {
+                setSelectedFriends([]);
+                setMembersModalVisible(false);
+              }}
+            >
+              <Text style={styles.secondaryButtonText}>Sulje</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </ScrollView>
+  );
+}

--- a/src/screens/GroupsScreen.js
+++ b/src/screens/GroupsScreen.js
@@ -443,6 +443,13 @@ const createGroup = async () => {
         <FlatList
           data={friendsList}
           keyExtractor={(item) => item.id}
+          style={{
+            maxHeight: 200, 
+            width: "100%",
+          }}
+          contentContainerStyle={{
+            paddingBottom: 20,
+          }}
           renderItem={({ item }) => {
             const selected = selectedFriends.includes(item.id);
 

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -280,13 +280,14 @@ if (isLoading) {
         animationType="slide"
         onRequestClose={() => setModalVisible(false)}
       >
-        <View style={styles.modalOverlay} />
-        <View style={styles.modalContainer}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContainer}>
           <Text style={styles.modalTitle}>Ystävät</Text>
 
           <FlatList
             data={friendsList}
             keyExtractor={(item) => item.id}
+            style={{ maxHeight: 300, width: "100%" }}
             contentContainerStyle={{ paddingBottom: 80 }}
             renderItem={({ item }) => {
               const date = item.createdAt?.toDate
@@ -308,9 +309,11 @@ if (isLoading) {
             }}
           />
 
-          <TouchableOpacity onPress={() => setModalVisible(false)}>
+          <TouchableOpacity onPress={() => setModalVisible(false)}
+            style={styles.closeButton}>
             <Text style={styles.modalClose}>Sulje</Text>
           </TouchableOpacity>
+        </View>
         </View>
       </Modal>
 

--- a/src/screens/SpecificGroupChat.js
+++ b/src/screens/SpecificGroupChat.js
@@ -8,8 +8,9 @@ import {
   KeyboardAvoidingView,
   Platform,
   Modal,
+  Alert,
 } from "react-native";
-import { useRoute } from "@react-navigation/native";
+import { useRoute, useNavigation } from "@react-navigation/native";
 import { useUser } from "../context/UserContext.js";
 import {
   firestore,
@@ -27,10 +28,12 @@ import DateDivider from "../components/dateDivider.js";
 import UserAvatar from "../components/UserAvatar.js";
 import Divider from "../components/Divider.js";
 import FontAwesome6 from '@expo/vector-icons/FontAwesome6';
+import { Ionicons } from "@expo/vector-icons";
 import {SvgUri} from 'react-native-svg';
 
 export default function SpecificGroupChat() {
   const route = useRoute();
+  const navigation = useNavigation();
   const user = useUser();
 
   const { groupId, groupName } = route.params;
@@ -42,6 +45,20 @@ export default function SpecificGroupChat() {
   const [groupData, setGroupData] = useState(null); 
   const [members, setMembers] = useState([]);
   const [membersModalVisible, setMembersModalVisible] = useState(false);
+
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const currentMember = members.find((member) => member.id === user?.uid);
+  const isAdmin = currentMember?.role === "admin";
+
+  const handleGroupAction = () => {
+      setMenuVisible(false);
+
+      navigation.navigate("EditGroup", {
+        groupId,
+        isAdmin,
+      });
+    };
 
   const getGroupAvatarUrl = (seed, style, name = "Group", size = 60) => {
   if (!seed || !style) return null;
@@ -336,6 +353,7 @@ export default function SpecificGroupChat() {
       <View style={{
           flexDirection: "row",
           alignItems: "center",
+          justifyContent: "space-between",
           paddingHorizontal: 30,
           paddingTop: 20,
           marginBottom: 16,
@@ -343,6 +361,7 @@ export default function SpecificGroupChat() {
       >
 
        {/* AVATAR */}
+       <View style={{flexDirection: "row", alignItems: "center", flex: 1}}>
   {(groupData?.avatarSeed && groupData?.avatarStyle) ? (
     <View
       style={{
@@ -374,15 +393,25 @@ export default function SpecificGroupChat() {
         style={{
           textAlign: "flex-start",
           fontSize: 32,
-          paddingHorizontal: 20,
+          paddingHorizontal: 10,
           paddingTop: 20,
           fontWeight: "bold",
           marginBottom: 16,
           
         }}
       >
-        {groupName || "Ryhmäkeskustelu"}
+        {groupData?.groupName ||groupName || "Ryhmäkeskustelu"}
       </Text>
+      </View>
+
+        <TouchableOpacity
+        onPress={() => setMenuVisible(true)}
+        style={{
+          marginLeft: 20,
+          padding: 8,}}
+      >
+        <Ionicons name="ellipsis-vertical" size={24} color="black" />
+      </TouchableOpacity>
       </View>
 
        <View
@@ -574,6 +603,55 @@ export default function SpecificGroupChat() {
             </View>
           </View>
         </Modal>
+
+        <Modal
+            visible={menuVisible}
+            transparent
+            animationType="fade"
+            onRequestClose={() => setMenuVisible(false)}
+          >
+            <TouchableOpacity
+              style={{
+                flex: 1,
+              }}
+              activeOpacity={1}
+              onPress={() => setMenuVisible(false)}
+            >
+              <View
+                style={{
+                  position: "absolute",
+                  top: 95,
+                  right: 20,
+                  backgroundColor: "white",
+                  borderRadius: 12,
+                  paddingVertical: 8,
+                  minWidth: 170,
+                  elevation: 6,
+                  shadowColor: "#000",
+                  shadowOpacity: 0.15,
+                  shadowRadius: 6,
+                  shadowOffset: { width: 0, height: 2 },
+                }}
+              >
+                <TouchableOpacity
+                  style={{
+                    paddingVertical: 12,
+                    paddingHorizontal: 16,
+                  }}
+                  onPress={handleGroupAction}
+                >
+                  <Text
+                    style={{
+                      fontSize: 16,
+                      color: "#111",
+                    }}
+                  >
+                    {isAdmin ? "Asetukset" : "Lisää jäseniä"}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </TouchableOpacity>
+          </Modal>
 
       </View>
     </KeyboardAvoidingView>

--- a/src/styles/EditGroup.js
+++ b/src/styles/EditGroup.js
@@ -1,0 +1,166 @@
+import { StyleSheet } from "react-native";
+
+export default StyleSheet.create({
+
+  container: {
+    padding: 20,
+    paddingBottom: 40,
+    backgroundColor: "#fff",
+  },
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: "bold",
+    marginBottom: 20,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 10,
+  },
+  avatarBox: {
+    marginBottom: 12,
+    alignItems: "flex-start",
+  },
+  avatarPlaceholder: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: "#ddd",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: "#fff",
+  },
+  multilineInput: {
+    minHeight: 100,
+    textAlignVertical: "top",
+  },
+  primaryButton: {
+    backgroundColor: "#f17a0a",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  primaryButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  secondaryButton: {
+    backgroundColor: "#eee",
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 4,
+  },
+  secondaryButtonText: {
+    color: "#111",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  deleteButton: {
+    backgroundColor: "#d62828",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 64,
+  },
+  deleteButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  memberRow: {
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+
+  removeMemberButton: {
+    backgroundColor: "#ffe5e5",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    marginLeft: 12,
+},
+
+  removeMemberButtonText: {
+    color: "#c62828",
+    fontWeight: "bold",
+    fontSize: 14,
+},
+  memberLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  memberName: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  memberRole: {
+    fontSize: 13,
+    color: "#666",
+    marginTop: 2,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.35)",
+    justifyContent: "center",
+    padding: 20,
+  },
+  modalContent: {
+    backgroundColor: "white",
+    borderRadius: 16,
+    padding: 20,
+    maxHeight: "75%",
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  friendRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+  },
+  disabledFriendRow: {
+    opacity: 0.6,
+  },
+
+  leaveButton: {
+    backgroundColor: "#d62828",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 8,
+},
+
+  leaveButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "bold",
+},
+});

--- a/src/styles/Groups.js
+++ b/src/styles/Groups.js
@@ -46,8 +46,8 @@ export default StyleSheet.create({
   },
   
   modalContainer: {
-    width: "85%",
-    maxHeight: "75%", 
+    width: "90%",
+    maxHeight: "85%", 
     backgroundColor: "white",
     borderRadius: 16,
     padding: 20,

--- a/src/styles/Profile.js
+++ b/src/styles/Profile.js
@@ -94,12 +94,11 @@ export default StyleSheet.create({
   alignItems: "center",
 },
   modalContainer: { 
-    width: "100%",
-    maxHeight: "70%",
+    width: "90%",
+    maxHeight: "80%",
     backgroundColor: "#fff",
-    paddingTop: 20,
-    paddingHorizontal: 30,
-    paddingBottom: 30,
+    padding: 20,
+   borderRadius:16,
     
   },
   modalTitle: { 
@@ -116,11 +115,8 @@ export default StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     marginBottom: 10,
-    borderBottomEndRadius: 10,
-    backgroundColor: "#f9f9f9",
-    borderBottomWidth: 1,
     borderBottomColor: "#eee",
-    elevation: 1,
+    borderBottomWidth: 1,
   },
 
   friendInfo: {
@@ -141,11 +137,17 @@ export default StyleSheet.create({
   },
  
   modalClose: { 
-    fontSize: 18, 
-    color: 'red', 
-    marginTop: 20, 
-    textAlign: 'center' 
+    textAlign: "center",
+    color: "white",
+    fontWeight: "bold",
   },
+
+  closeButton: {
+    marginTop: 20,
+    backgroundColor: "#f17a0a",
+    padding: 12,
+    borderRadius: 8,
+},
   bottomHomeButton: {
     position: "absolute",
     bottom: 20,


### PR DESCRIPTION
Admin pääsee muokkaamaan ryhmän tietoja (kuva,nimi,teksti) menu-valikon kautta, joka vie editGroup-sivulle. Asetuksissa näkyy myös kaikki ryhmän jäsenet ja nimen vierestä voi poistaa ryhmäläisen. Tämän jälkeen ryhmä katoaa kyseiseltä henkilöltä omalta group-sivultaan. "Lisää jäseniä"-nappi avaa valikon, josta voi lisätä omia kavereitaan ryhmään. Listassa näkyy mikäli henkilö kuuluu jo kyseiseen ryhmään eikä sitä näin ollen voi lisätä uudelleen. Alhaalla on punainen nappi, josta onnistuu koko ryhmän poisto.
Membereille avautuu menu-valikosta vain "lisää jäseniä"-vaihtoehto, joka vie editGroup-sivulle, mutta sieltä ei voi tehdä muuta kuin lisätä jäseniä ryhmään tai poistua itse ryhmästä. 
Kun jäsen lisätään tai poistetaan ryhmästä, siitä ei tule vielä mitään ilmoitusta. Admin ei voi poistua ryhmästä vaan tällä hetkellä se poistaa koko ryhmän. Tähän pitää tehdä se kysely admin-oikeuksien siirrosta yms.